### PR TITLE
Fix: Improve error handling and return values in execute_command

### DIFF
--- a/4_execute_command.c
+++ b/4_execute_command.c
@@ -8,25 +8,26 @@
  *
  * Return: 1 if error, 0 if success
  */
+
 int execute_command(char **command, char **env, char *shell_name)
 {
 	pid_t child_pid;
 	int child_status;
 
 	if (command == NULL || command[0] == NULL || command[0][0] == '\0')
-		return (0);								/** Return if command is empty or NULL */
+		return (0);									/** Return if command is empty or NULL */
 
 
-	child_pid = fork();						/** Create a child process */
-	if (child_pid == -1)					/** Check if child process failed */
+	child_pid = fork();								/** Create a child process */
+	if (child_pid == -1)							/** Check if child process failed */
 	{
 		perror("Fork error");
 		return (1);
 	}
 
-	if (child_pid == 0)						/** Child process */
+	if (child_pid == 0)								/** Child process */
 	{
-		if (access(command[0], X_OK) == -1)	/** Check if executable */
+		if (access(command[0], X_OK) == -1)			/** Check if executable */
 		{
 			fprintf(stderr, "%s: 1: %s: not found\n", shell_name, command[0]);
 			exit(EXIT_FAILURE);
@@ -39,8 +40,12 @@ int execute_command(char **command, char **env, char *shell_name)
 		}
 	}
 	else
-	{
-		wait(&child_status);				/** Wait for the child process to finish */
+		{
+			wait(&child_status);					/** Wait for the child process to finish */
+			if (WIFEXITED(child_status))
+			{
+				return (WEXITSTATUS(child_status)); /** Return child's exit status */
+			}
+		}
+		return (1);									/** If wait fails, return error */
 	}
-	return (0);
-}


### PR DESCRIPTION
- Added check for child process termination status using WIFEXITED
- Return the exit status of the child process using WEXITSTATUS
- Return error (1) if wait fails or child process doesn't exit normally
- Adjusted indentation for better readability
- Improved comments for clarity