### PR TITLE
Fix Exit Status Handling in Main Function

### DIFF
--- a/main.c
+++ b/main.c
@@ -43,11 +43,10 @@ int main(int argc, char **argv, char **env)
 			continue;												/** Skip to next iteration */
 		}
 
-		execute_command(tokenised_command, env, argv[0]);			/** Exec given comm */
-
+		status = execute_command(tokenised_command, env, argv[0]);
+		exitstatus = status;
 		free(command);												/** Free memory allocated for command */
 		free_tokenised_command(tokenised_command);					/** Free tokenized command */
 	}
-		exitstatus = WEXITSTATUS(status);
 		return (exitstatus);
 }


### PR DESCRIPTION
- Updated the initialization of the `status` variable in the `main` function to correctly capture the return value of `execute_command`.
- Modified the exit condition to use the `exitstatus` variable, which now reflects the status of the last executed command.
- Ensured that the `exitstatus` is returned at the end of the `main` function.